### PR TITLE
def clean_employee

### DIFF
--- a/hr/forms.py
+++ b/hr/forms.py
@@ -1,5 +1,6 @@
 import calendar
 from datetime import date
+from django.core.exceptions import ValidationError
 
 from django import forms
 from django.forms import ChoiceField
@@ -42,3 +43,33 @@ class SalaryForm(forms.Form):
                     choices=WorkDayChoices,
                     initial=WorkDayEnum.WORKING_DAY.name,
                 )
+
+    def clean_employee(self):
+        employee = self.cleaned_data.get('employee')
+        if not employee:
+            raise forms.ValidationError("ValidationError: employee field  must be filled in")
+        return employee
+
+    def clean(self):
+        cleaned_data = super().clean()
+        sick_days_count = 0
+        holiday_days_count = 0
+        max_sick_days_count = 5
+        max_holiday_days_count = 3
+
+        for day in range(1, 32):
+            field_name = f'day_{day}'
+            work_day_status = cleaned_data.get(field_name)
+
+            if work_day_status == WorkDayEnum.SICK_DAY.name:
+                sick_days_count += 1
+            elif work_day_status == WorkDayEnum.HOLIDAY.name:
+                holiday_days_count += 1
+
+        if sick_days_count > max_sick_days_count:
+            raise forms.ValidationError(f"Кількість лікарняних днів не може бути більшою за {max_sick_days_count} днів")
+
+        if holiday_days_count > max_holiday_days_count:
+            raise forms.ValidationError(f"Кількість днів відпочинку не повинна перевищувати {max_holiday_days_count}.")
+
+        return cleaned_data

--- a/templates/salary_calculator.html
+++ b/templates/salary_calculator.html
@@ -3,6 +3,8 @@
 {% block content %}
   <h1>Salary calculator</h1>
 
+
+
   <!-- Відображення помилок на рівні форми -->
   {% if form.non_field_errors %}
     <div class="alert alert-danger mt-4" role="alert">
@@ -39,6 +41,9 @@
         </div>
       {% endif %}
     </div>
+
+
+
 
     <div class="row">
       {% for field in form %}


### PR DESCRIPTION
Displaying errors when the sick leave limit is exceeded and holiday is working properly. But the error text in the case when the employee field is empty is not displayed. Or rather, it will appear, but not what I want. As I understand it, I need to remove the standard check for an empty field somewhere and then mine will work, but I haven’t figured out how yet